### PR TITLE
Fix admin middleware alias

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -8,6 +8,36 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller; // Ensure correct Controller is imported
 class CategoryController extends Controller
 {
+    // Resource methods expected by Route::resource
+    public function index()
+    {
+        return $this->categoriesIndex();
+    }
+
+    public function create()
+    {
+        return $this->categoryCreate();
+    }
+
+    public function store(Request $request)
+    {
+        return $this->categoryStore($request);
+    }
+
+    public function edit(Category $category)
+    {
+        return $this->categoryEdit($category);
+    }
+
+    public function update(Request $request, Category $category)
+    {
+        return $this->categoryUpdate($request, $category);
+    }
+
+    public function destroy(Category $category)
+    {
+        return $this->categoryDestroy($category);
+    }
     // Manajemen Kategori
     public function categoriesIndex()
     {

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -18,6 +18,27 @@ class UserController extends Controller
         $this->middleware('admin');
     }
 
+    // Resource methods expected by Route::resource
+    public function index()
+    {
+        return $this->usersIndex();
+    }
+
+    public function edit(User $user)
+    {
+        return $this->userEdit($user);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        return $this->userUpdate($request, $user);
+    }
+
+    public function destroy(User $user)
+    {
+        return $this->userDestroy($user);
+    }
+
     public function usersIndex()
     {
         return view('dashboard.admin.users.index', [

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // Register custom middleware aliases
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
## Summary
- register `admin` middleware alias in `bootstrap/app.php`

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684af470138c8324b91f1b90426a77db