### PR TITLE
Fix user role update

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -8,6 +8,36 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller; // Ensure correct Controller is imported
 class CategoryController extends Controller
 {
+    // Resource methods expected by Route::resource
+    public function index()
+    {
+        return $this->categoriesIndex();
+    }
+
+    public function create()
+    {
+        return $this->categoryCreate();
+    }
+
+    public function store(Request $request)
+    {
+        return $this->categoryStore($request);
+    }
+
+    public function edit(Category $category)
+    {
+        return $this->categoryEdit($category);
+    }
+
+    public function update(Request $request, Category $category)
+    {
+        return $this->categoryUpdate($request, $category);
+    }
+
+    public function destroy(Category $category)
+    {
+        return $this->categoryDestroy($category);
+    }
     // Manajemen Kategori
     public function categoriesIndex()
     {

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -18,6 +18,27 @@ class UserController extends Controller
         $this->middleware('admin');
     }
 
+    // Resource methods expected by Route::resource
+    public function index()
+    {
+        return $this->usersIndex();
+    }
+
+    public function edit(User $user)
+    {
+        return $this->userEdit($user);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        return $this->userUpdate($request, $user);
+    }
+
+    public function destroy(User $user)
+    {
+        return $this->userDestroy($user);
+    }
+
     public function usersIndex()
     {
         return view('dashboard.admin.users.index', [
@@ -36,8 +57,11 @@ class UserController extends Controller
             'name' => 'required|max:255',
             'username' => ['required', 'max:255', Rule::unique('users')->ignore($user->id)],
             'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
-            'is_admin' => 'boolean'
+            'is_admin' => 'boolean',
         ]);
+
+        // Explicitly cast admin checkbox to boolean so unchecked state is saved
+        $validatedData['is_admin'] = $request->boolean('is_admin');
 
         $user->update($validatedData);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // Register custom middleware aliases
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/resources/views/dashboard/admin/categories/edit.blade.php
+++ b/resources/views/dashboard/admin/categories/edit.blade.php
@@ -2,15 +2,15 @@
 
 @section('container')
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h1 class="h2">Create New Category</h1>
+        <h1 class="h2">Edit Category</h1>
     </div>
 
-    <form method="POST" action="{{ route('admin.categories.store') }}">
+    <form method="POST" action="{{ route('admin.categories.update', $category->id) }}">
         @csrf
+        @method('PUT')
         <div class="mb-3">
             <label for="name" class="form-label">Category Name</label>
-            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name"
-                required>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $category->name) }}" required>
             @error('name')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
@@ -18,10 +18,10 @@
 
         <div class="mb-3">
             <label for="description" class="form-label">Description</label>
-            <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+            <textarea class="form-control" id="description" name="description" rows="3">{{ old('description', $category->description) }}</textarea>
         </div>
 
-        <button type="submit" class="btn btn-primary">Create Category</button>
+        <button type="submit" class="btn btn-primary">Update Category</button>
         <a href="{{ route('admin.categories.index') }}" class="btn btn-secondary">Cancel</a>
     </form>
 @endsection

--- a/resources/views/dashboard/admin/categories/index.blade.php
+++ b/resources/views/dashboard/admin/categories/index.blade.php
@@ -3,7 +3,7 @@
 @section('container')
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
         <h1 class="h2">Manage Categories</h1>
-        <a href="{{ route('dashboard.admin.categories.create') }}" class="btn btn-primary">Create New Category</a>
+        <a href="{{ route('admin.categories.create') }}" class="btn btn-primary">Create New Category</a>
     </div>
 
     @if (session('success'))

--- a/resources/views/dashboard/admin/users/edit.blade.php
+++ b/resources/views/dashboard/admin/users/edit.blade.php
@@ -5,7 +5,7 @@
         <h1 class="h2">Edit User</h1>
     </div>
 
-    <form method="POST" action="{{ route('admin.users.update', $user->id) }}">
+    <form method="POST" action="{{ route('admin.users.update', $user->username) }}">
         @csrf
         @method('PUT')
         <div class="mb-3">

--- a/resources/views/dashboard/admin/users/index.blade.php
+++ b/resources/views/dashboard/admin/users/index.blade.php
@@ -44,10 +44,10 @@
                             @endif
                         </td>
                         <td>
-                            <a href="{{ route('admin.users.edit', $user->id) }}" class="badge bg-warning">
+                            <a href="{{ route('admin.users.edit', $user->username) }}" class="badge bg-warning">
                                 <span data-feather="edit"></span>
                             </a>
-                            <form action="{{ route('admin.users.destroy', $user->id) }}" method="POST" class="d-inline">
+                            <form action="{{ route('admin.users.destroy', $user->username) }}" method="POST" class="d-inline">
                                 @csrf
                                 @method('DELETE')
                                 <button type="submit" class="badge bg-danger border-0"


### PR DESCRIPTION
## Summary
- ensure admin checkbox properly updates the `is_admin` flag
- add resource wrappers for Category/User controllers
- register custom admin middleware alias
- use username for edit/delete routes on users
- fix admin category views

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684af470138c8324b91f1b90426a77db