### PR TITLE
Fix edit user form

### DIFF
--- a/resources/views/dashboard/admin/users/edit.blade.php
+++ b/resources/views/dashboard/admin/users/edit.blade.php
@@ -5,36 +5,39 @@
         <h1 class="h2">Edit User</h1>
     </div>
 
-    <form method="POST" action="{{ route('admin.users.update', $user->id) }}">
+    <form method="POST" action="{{ route('admin.users.update', $user->username) }}">
         @csrf
         @method('PUT')
         <div class="mb-3">
             <label for="name" class="form-label">Name</label>
-            <input type="text" class="form-control" id="name" name="name" value="{{ old('name', $user->name) }}"
-                required>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $user->name) }}" required>
+            @error('name')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
         </div>
 
-                <div class="mb-3">
-                    <label for="username" class="form-label">Username</label>
-                    <input type="text" class="form-control" id="username" name="username"
-                        value="{{ old('username', $user->username) }}" required>
-                </div>
-
-                <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email"
-                        value="{{ old('email', $user->email) }}" required>
-                </div>
-
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" value="1"
-                        {{ $user->isAdmin ? 'checked' : '' }}>
-                    <label class="form-check-label" for="is_admin">Admin User</label>
-                </div>
-
-                <button type="submit" class="btn btn-primary">Update User</button>
-                <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Cancel</a>
-            </form>
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control @error('username') is-invalid @enderror" id="username" name="username" value="{{ old('username', $user->username) }}" required>
+            @error('username')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
         </div>
-    </div>
+
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control @error('email') is-invalid @enderror" id="email" name="email" value="{{ old('email', $user->email) }}" required>
+            @error('email')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+
+        <div class="mb-3 form-check">
+            <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" value="1" {{ $user->isAdmin ? 'checked' : '' }}>
+            <label class="form-check-label" for="is_admin">Admin User</label>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Update User</button>
+        <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
 @endsection


### PR DESCRIPTION
## Summary
- fix admin edit user form to use username for route
- display validation errors when editing users

## Testing
- `composer test` *(fails: composer not installed)*
- `vendor/bin/phpunit` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b02b1ee588324b0c988a392b00039