### PR TITLE
Fix edit user form

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -42,7 +42,7 @@ class CategoryController extends Controller
     public function categoriesIndex()
     {
         return view('dashboard.admin.categories.index', [
-            'categories' => Category::latest()->paginate(10),
+            'categories' => Category::withCount('posts')->latest()->paginate(10),
             'title' => 'Manage Categories'
         ]);
     }
@@ -90,7 +90,7 @@ class CategoryController extends Controller
     public function categoryDestroy(Category $category)
     {
         // Cek apakah kategori digunakan oleh postingan
-        if ($category->blogs()->exists()) {
+        if ($category->posts()->exists()) {
             return redirect()->route('admin.categories.index')
                 ->with('error', 'Cannot delete category with associated posts');
         }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -42,7 +42,7 @@ class UserController extends Controller
     public function usersIndex()
     {
         return view('dashboard.admin.users.index', [
-            'users' => User::latest()->paginate(10),
+            'users' => User::withCount('blogs')->latest()->paginate(10),
             'title' => 'Manage Users'
         ]);
     }

--- a/resources/views/dashboard/admin/categories/edit.blade.php
+++ b/resources/views/dashboard/admin/categories/edit.blade.php
@@ -5,7 +5,7 @@
         <h1 class="h2">Edit Category</h1>
     </div>
 
-    <form method="POST" action="{{ route('admin.categories.update', $category->id) }}">
+    <form method="POST" action="{{ route('admin.categories.update', $category->slug) }}">
         @csrf
         @method('PUT')
         <div class="mb-3">

--- a/resources/views/dashboard/admin/categories/index.blade.php
+++ b/resources/views/dashboard/admin/categories/index.blade.php
@@ -26,6 +26,7 @@
                     <th>Name</th>
                     <th>Slug</th>
                     <th>Description</th>
+                    <th>Posts</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -36,11 +37,12 @@
                         <td>{{ $category->name }}</td>
                         <td>{{ $category->slug }}</td>
                         <td>{{ $category->description ?? '-' }}</td>
+                        <td>{{ $category->posts_count }}</td>
                         <td>
-                            <a href="{{ route('admin.categories.edit', $category->id) }}" class="badge bg-warning">
+                            <a href="{{ route('admin.categories.edit', $category->slug) }}" class="badge bg-warning">
                                 <span data-feather="edit"></span>
                             </a>
-                            <form action="{{ route('admin.categories.destroy', $category->id) }}" method="POST"
+                            <form action="{{ route('admin.categories.destroy', $category->slug) }}" method="POST"
                                 class="d-inline">
                                 @csrf
                                 @method('DELETE')

--- a/resources/views/dashboard/admin/users/edit.blade.php
+++ b/resources/views/dashboard/admin/users/edit.blade.php
@@ -5,36 +5,39 @@
         <h1 class="h2">Edit User</h1>
     </div>
 
-    <form method="POST" action="{{ route('admin.users.update', $user->id) }}">
+    <form method="POST" action="{{ route('admin.users.update', $user->username) }}">
         @csrf
         @method('PUT')
         <div class="mb-3">
             <label for="name" class="form-label">Name</label>
-            <input type="text" class="form-control" id="name" name="name" value="{{ old('name', $user->name) }}"
-                required>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $user->name) }}" required>
+            @error('name')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
         </div>
 
-                <div class="mb-3">
-                    <label for="username" class="form-label">Username</label>
-                    <input type="text" class="form-control" id="username" name="username"
-                        value="{{ old('username', $user->username) }}" required>
-                </div>
-
-                <div class="mb-3">
-                    <label for="email" class="form-label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email"
-                        value="{{ old('email', $user->email) }}" required>
-                </div>
-
-                <div class="mb-3 form-check">
-                    <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" value="1"
-                        {{ $user->isAdmin ? 'checked' : '' }}>
-                    <label class="form-check-label" for="is_admin">Admin User</label>
-                </div>
-
-                <button type="submit" class="btn btn-primary">Update User</button>
-                <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Cancel</a>
-            </form>
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control @error('username') is-invalid @enderror" id="username" name="username" value="{{ old('username', $user->username) }}" required>
+            @error('username')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
         </div>
-    </div>
+
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control @error('email') is-invalid @enderror" id="email" name="email" value="{{ old('email', $user->email) }}" required>
+            @error('email')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+
+        <div class="mb-3 form-check">
+            <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" value="1" {{ $user->isAdmin ? 'checked' : '' }}>
+            <label class="form-check-label" for="is_admin">Admin User</label>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Update User</button>
+        <a href="{{ route('admin.users.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
 @endsection

--- a/resources/views/dashboard/admin/users/index.blade.php
+++ b/resources/views/dashboard/admin/users/index.blade.php
@@ -25,6 +25,7 @@
                     <th>Name</th>
                     <th>Username</th>
                     <th>Email</th>
+                    <th>Posts</th>
                     <th>Role</th>
                     <th>Actions</th>
                 </tr>
@@ -36,6 +37,7 @@
                         <td>{{ $user->name }}</td>
                         <td>{{ $user->username }}</td>
                         <td>{{ $user->email }}</td>
+                        <td>{{ $user->blogs_count }}</td>
                         <td>
                             @if ($user->isAdmin)
                                 <span class="badge bg-success">Admin</span>


### PR DESCRIPTION
## Summary
- fix admin edit user form to use username for route
- display validation errors when editing users
- show blog counts in admin user and category lists
- fix admin category view links to use slugs
- prevent deleting categories that contain posts

## Testing
- `composer test` *(fails: composer not installed)*
- `vendor/bin/phpunit` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b02b1ee588324b0c988a392b00039