### PR TITLE
Add profile view & edit functionality

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class AccountController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function show()
+    {
+        $user = Auth::user();
+        return view('dashboard.account.show', [
+            'title' => 'My Profile',
+            'user' => $user,
+        ]);
+    }
+
+    public function edit()
+    {
+        $user = Auth::user();
+        return view('dashboard.account.edit', [
+            'title' => 'Edit Profile',
+            'user' => $user,
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $user = Auth::user();
+
+        $validatedData = $request->validate([
+            'name' => 'required|max:255',
+            'username' => ['required', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
+            'password' => ['nullable', 'min:5'],
+        ]);
+
+        if (empty($validatedData['password'])) {
+            unset($validatedData['password']);
+        } else {
+            $validatedData['password'] = bcrypt($validatedData['password']);
+        }
+
+        $user->update($validatedData);
+
+        return redirect()->route('account.show')->with('success', 'Profile updated successfully');
+    }
+}

--- a/resources/views/dashboard/account/edit.blade.php
+++ b/resources/views/dashboard/account/edit.blade.php
@@ -1,0 +1,41 @@
+@extends('dashboard.layouts.main')
+
+@section('container')
+<div class="container">
+    <h1 class="mb-4">Edit Profile</h1>
+    <form method="POST" action="{{ route('account.update') }}">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label for="name" class="form-label">Name</label>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $user->name) }}" required>
+            @error('name')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control @error('username') is-invalid @enderror" id="username" name="username" value="{{ old('username', $user->username) }}" required>
+            @error('username')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control @error('email') is-invalid @enderror" id="email" name="email" value="{{ old('email', $user->email) }}" required>
+            @error('email')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password (leave blank to keep current)</label>
+            <input type="password" class="form-control @error('password') is-invalid @enderror" id="password" name="password">
+            @error('password')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <a href="{{ route('account.show') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/dashboard/account/show.blade.php
+++ b/resources/views/dashboard/account/show.blade.php
@@ -1,0 +1,16 @@
+@extends('dashboard.layouts.main')
+
+@section('container')
+<div class="container">
+    <h1 class="mb-4">My Profile</h1>
+    <dl class="row">
+        <dt class="col-sm-3">Name</dt>
+        <dd class="col-sm-9">{{ $user->name }}</dd>
+        <dt class="col-sm-3">Username</dt>
+        <dd class="col-sm-9">{{ $user->username }}</dd>
+        <dt class="col-sm-3">Email</dt>
+        <dd class="col-sm-9">{{ $user->email }}</dd>
+    </dl>
+    <a href="{{ route('account.edit') }}" class="btn btn-primary">Edit Profile</a>
+</div>
+@endsection

--- a/resources/views/dashboard/layouts/partials/accounts.blade.php
+++ b/resources/views/dashboard/layouts/partials/accounts.blade.php
@@ -1,10 +1,10 @@
 <div class="tab-content" id="mysrpTabContent">
     <div class="tab-pane fade show active" id="drp-tab-1" role="tabpanel" aria-labelledby="drp-t1" tabindex="0">
-        <a href="#!" class="dropdown-item">
+        <a href="{{ route('account.edit') }}" class="dropdown-item">
             <i class="ti ti-edit-circle"></i>
             <span>Edit Profile</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="{{ route('account.show') }}" class="dropdown-item">
             <i class="ti ti-user"></i>
             <span>View Profile</span>
         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\DashboardPostController;
+use App\Http\Controllers\AccountController;
 
 Route::get("/", function () {
     return view(
@@ -67,6 +68,11 @@ Route::middleware('guest')->group(function () {
 Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
+
+    // Profile routes
+    Route::get('/account', [AccountController::class, 'show'])->name('account.show');
+    Route::get('/account/edit', [AccountController::class, 'edit'])->name('account.edit');
+    Route::put('/account', [AccountController::class, 'update'])->name('account.update');
 
     // Rute untuk cek slug
     Route::get('/dashboard/blog/checkSlug', [DashboardPostController::class, 'checkSlug'])


### PR DESCRIPTION
## Summary
- add AccountController to handle profile display and update
- create profile show and edit views
- update account dropdown to link to new pages
- register profile routes

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd919da94832c86d79770c12dc6d9