### PR TITLE
Improve home and about pages

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Blog;
 
-class AboutController extends Controller
+class HomeController extends Controller
 {
     public function index()
     {
@@ -14,8 +13,8 @@ class AboutController extends Controller
             ->take(3)
             ->get();
 
-        return view('about', [
-            'title' => 'About Us',
+        return view('index', [
+            'title' => 'Home',
             'popularPosts' => $popularPosts,
         ]);
     }

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -47,4 +47,16 @@
 
     </section>
     <!-- /About Section -->
+
+    @if ($popularPosts->count())
+        <!-- Popular Posts Section -->
+        <section id="popular-posts" class="blog section">
+            <div class="container">
+                <div class="section-header">
+                    <h2>Popular Posts</h2>
+                </div>
+                @include('partials.posts-grid', ['posts' => $popularPosts])
+            </div>
+        </section>
+    @endif
 @endsection

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -95,5 +95,17 @@
           </div>
 
       </section><!-- /About Section -->
+
+      @if ($popularPosts->count())
+          <!-- Popular Posts Section -->
+          <section id="popular-posts" class="blog section">
+              <div class="container">
+                  <div class="section-header">
+                      <h2>Popular Posts</h2>
+                  </div>
+                  @include('partials.posts-grid', ['posts' => $popularPosts])
+              </div>
+          </section>
+      @endif
   @endsection
 

--- a/resources/views/partials/posts-grid.blade.php
+++ b/resources/views/partials/posts-grid.blade.php
@@ -1,0 +1,43 @@
+<div class="container">
+    <div class="row gy-4">
+        @foreach ($posts as $post)
+            <div class="col-lg-4">
+                <article class="position-relative h-100">
+                    <div class="post-img position-relative overflow-hidden">
+                        @if ($post->image)
+                            <img src="{{ asset('storage/' . $post->image) }}" class="img-fluid" alt="">
+                        @else
+                            @if ($post->category)
+                                <img src="https://picsum.photos/1200/800??{{ $post->category->name }}" class="img-fluid" alt="">
+                            @else
+                                <img src="https://picsum.photos/1200/800" class="img-fluid" alt="">
+                            @endif
+                        @endif
+                    </div>
+
+                    <div class="post-content d-flex flex-column">
+                        <h3 class="post-title">{{ $post->title }}</h3>
+                        <div class="meta d-flex align-items-center">
+                            <div class="d-flex align-items-center">
+                                <a href="/blog?author={{ $post->author->username }}" class="text-decoration-none">
+                                    <i class="bi bi-person"></i> <span class="ps-2">{{ $post->author->name }}</span>
+                                </a>
+                            </div>
+                            <span class="px-3 text-black-50">/</span>
+                            <div class="d-flex align-items-center">
+                                <a href="/blog?category={{ $post->category->name }}" class="text-decoration-none ">
+                                    <i class="bi bi-folder2"></i>
+                                    <span class="ps-2">{{ $post->category->name }}</span>
+                                </a>
+                            </div>
+                        </div>
+                        <p>{{ $post->excerpt }}</p>
+                        <span class="post-date"><i class="bi bi-clock"></i> <time datetime="{{ $post->created_at }}">{{ $post->created_at->diffForHumans() }}</time></span>
+                        <hr>
+                        <a href="/blog/{{ $post->slug }}" class="readmore"><span>Read More</span><i class="bi bi-arrow-right"></i></a>
+                    </div>
+                </article>
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\BlogController;
 use App\Http\Controllers\AboutController;
+use App\Http\Controllers\HomeController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\CommentController;
@@ -15,14 +16,7 @@ use App\Http\Controllers\Admin\CategoryController as AdminCategory;
 use App\Http\Controllers\DashboardPostController;
 use App\Http\Controllers\AccountController;
 
-Route::get("/", function () {
-    return view(
-        "index",
-        [
-            "title" => "Home"
-        ]
-    );
-});
+Route::get('/', [HomeController::class, 'index'])->name('home');
 
 Route::get("/about", [AboutController::class, 'index'])->name('about.index');
 


### PR DESCRIPTION
## Summary
- show popular posts on the home page
- show the same popular posts on the about page
- add HomeController and partial for post grid
- route `/` handled by HomeController

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684bf9577400832c900487be152d8109