### PR TITLE
Add alumni trace feature

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -40,6 +40,7 @@ class AccountController extends Controller
             'name' => 'required|max:255',
             'username' => ['required', 'max:255', Rule::unique('users')->ignore($user->id)],
             'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
+            'bio' => 'nullable|string',
             'password' => ['nullable', 'min:5'],
         ]);
 

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -57,6 +57,7 @@ class UserController extends Controller
             'name' => 'required|max:255',
             'username' => ['required', 'max:255', Rule::unique('users')->ignore($user->id)],
             'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
+            'bio' => 'nullable|string',
             'is_admin' => 'boolean',
         ]);
 

--- a/app/Http/Controllers/AlumniController.php
+++ b/app/Http/Controllers/AlumniController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class AlumniController extends Controller
+{
+    public function index()
+    {
+        $alumni = User::where('is_admin', false)->paginate(10);
+        return view('alumni.index', [
+            'title' => 'Alumni',
+            'alumni' => $alumni,
+        ]);
+    }
+
+    public function show(User $user)
+    {
+        $user->load('blogs');
+        return view('alumni.show', [
+            'title' => $user->name,
+            'alumnus' => $user,
+            'posts' => $user->blogs()->latest()->get(),
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'email',
         'password',
         'username',
+        'bio',
         'is_admin',
     ];
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
             'is_admin' => false,
+            'bio' => fake()->paragraph(),
         ];
     }
 

--- a/database/migrations/2025_06_20_000001_add_bio_to_users_table.php
+++ b/database/migrations/2025_06_20_000001_add_bio_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('bio')->nullable()->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('bio');
+        });
+    }
+};

--- a/resources/views/alumni/index.blade.php
+++ b/resources/views/alumni/index.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.main')
+@php use Illuminate\Support\Str; @endphp
+
+@section('container')
+    <section class="container my-5">
+        <h1 class="mb-4">Alumni</h1>
+        <div class="row">
+            @foreach ($alumni as $user)
+                <div class="col-md-4 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <a href="{{ route('alumni.show', $user->username) }}" class="text-decoration-none">
+                                    {{ $user->name }}
+                                </a>
+                            </h5>
+                            @if($user->bio)
+                                <p class="card-text">{{ Str::limit($user->bio, 80) }}</p>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+        {{ $alumni->links() }}
+    </section>
+@endsection

--- a/resources/views/alumni/show.blade.php
+++ b/resources/views/alumni/show.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.main')
+
+@section('container')
+    <section class="container my-5">
+        <h1 class="mb-3">{{ $alumnus->name }}</h1>
+        @if($alumnus->bio)
+            <p class="mb-4">{{ $alumnus->bio }}</p>
+        @endif
+        @if($posts->count())
+            <h3 class="mt-5 mb-3">Posts</h3>
+            @include('partials.posts-grid', ['posts' => $posts])
+        @else
+            <p>No posts yet.</p>
+        @endif
+    </section>
+@endsection

--- a/resources/views/dashboard/account/edit.blade.php
+++ b/resources/views/dashboard/account/edit.blade.php
@@ -28,6 +28,13 @@
             @enderror
         </div>
         <div class="mb-3">
+            <label for="bio" class="form-label">Bio</label>
+            <textarea class="form-control @error('bio') is-invalid @enderror" id="bio" name="bio" rows="3">{{ old('bio', $user->bio) }}</textarea>
+            @error('bio')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3">
             <label for="password" class="form-label">Password (leave blank to keep current)</label>
             <input type="password" class="form-control @error('password') is-invalid @enderror" id="password" name="password">
             @error('password')

--- a/resources/views/dashboard/account/show.blade.php
+++ b/resources/views/dashboard/account/show.blade.php
@@ -10,6 +10,10 @@
         <dd class="col-sm-9">{{ $user->username }}</dd>
         <dt class="col-sm-3">Email</dt>
         <dd class="col-sm-9">{{ $user->email }}</dd>
+        @if($user->bio)
+            <dt class="col-sm-3">Bio</dt>
+            <dd class="col-sm-9">{{ $user->bio }}</dd>
+        @endif
     </dl>
     <a href="{{ route('account.edit') }}" class="btn btn-primary">Edit Profile</a>
 </div>

--- a/resources/views/dashboard/admin/users/edit.blade.php
+++ b/resources/views/dashboard/admin/users/edit.blade.php
@@ -34,6 +34,13 @@
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>
+        <div class="mb-3">
+            <label for="bio" class="form-label">Bio</label>
+            <textarea class="form-control @error('bio') is-invalid @enderror" id="bio" name="bio" rows="3">{{ old('bio', $user->bio) }}</textarea>
+            @error('bio')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
 
         <div class="mb-3 form-check">
             <input type="checkbox" class="form-check-input" id="is_admin" name="is_admin" value="1"

--- a/resources/views/layouts/partials/navbar.blade.php
+++ b/resources/views/layouts/partials/navbar.blade.php
@@ -4,6 +4,7 @@
         <li><a href="/about" class="{{ request()->is('about*') ? 'active' : '' }}">About</a></li>
         <li><a href="/blog" class="{{ request()->is('blog*') ? 'active' : '' }}">Blog</a></li>
         <li><a href="/categories" class="{{ request()->is('categories') ? 'active' : '' }}">categories</a></li>
+        <li><a href="/alumni" class="{{ request()->is('alumni*') ? 'active' : '' }}">Alumni</a></li>
         <li>
             <a href="#" data-bs-toggle="modal" data-bs-target="#searchModal">
                 <i class="bi bi-search"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,10 +15,13 @@ use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\CategoryController as AdminCategory;
 use App\Http\Controllers\DashboardPostController;
 use App\Http\Controllers\AccountController;
+use App\Http\Controllers\AlumniController;
 
 Route::get('/', [HomeController::class, 'index'])->name('home');
 
 Route::get("/about", [AboutController::class, 'index'])->name('about.index');
+Route::get('/alumni', [AlumniController::class, 'index'])->name('alumni.index');
+Route::get('/alumni/{user:username}', [AlumniController::class, 'show'])->name('alumni.show');
 
 
 Route::resource('/blog', BlogController::class)->parameters(['blog' => 'blog:slug']);


### PR DESCRIPTION
## Summary
- allow storing user bio
- manage bio in account settings and admin panel
- list alumni and show their posts
- display alumni menu item

## Testing
- `vendor/bin/phpunit --version` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c43704434832c9d9f8f50e08fec36