### PR TITLE
Remove extra dashboard assets

### DIFF
--- a/resources/views/dashboard/layouts/main.blade.php
+++ b/resources/views/dashboard/layouts/main.blade.php
@@ -15,7 +15,7 @@
     <meta name="author" content="CodedThemes">
 
     <!-- [Favicon] icon -->
-    @include('layouts.partials.vendor.css')
+    @include('dashboard.layouts.partials.css')
 
 </head>
 <!-- [Head] end -->
@@ -71,14 +71,7 @@
         {{-- <script src="../assets/js/plugins/apexcharts.min.js"></script> --}}
         {{-- <script src="../assets/js/pages/dashboard-default.js"></script> --}}
         <!-- [Page Specific JS] end -->
-        <!-- Required Js -->
-        <script src="{{ asset('assets/js/plugins/popper.min.js') }}"></script>
-        <script src="{{ asset('assets/js/plugins/simplebar.min.js') }}"></script>
-        <script src="{{ asset('assets/js/plugins/bootstrap.min.js') }}"></script>
-        <script src="{{ asset('assets/js/fonts/custom-font.js') }}"></script>
-        {{-- <script src="{{ asset('assets/js/pcoded.js') }}"></script> --}}
-        <script src="{{ asset('assets/js/plugins/feather.min.js') }}"></script>
-        <script src="{{ asset('assets/js/trix.js') }}"></script>
+        @include('dashboard.layouts.partials.js')
 
 
 
@@ -110,7 +103,7 @@
             font_change("Public-Sans");
         </script> --}}
 
-        @include('layouts.partials.vendor.js')
+
 
 </body>
 <!-- [Body] end -->

--- a/resources/views/dashboard/layouts/partials/css.blade.php
+++ b/resources/views/dashboard/layouts/partials/css.blade.php
@@ -1,0 +1,10 @@
+<link rel="icon" href="{{ asset('assets/img/favicon.svg') }}" type="image/x-icon">
+<link rel="stylesheet" href="{{ asset('assets/vendor/bootstrap/css/bootstrap.min.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/vendor/bootstrap-icons/bootstrap-icons.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/fonts/tabler-icons.min.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/fonts/feather.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/fonts/fontawesome.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/fonts/material.css') }}">
+<link rel="stylesheet" href="{{ asset('assets/css/style.css') }}" id="main-style-link">
+<link rel="stylesheet" href="{{ asset('assets/css/style-preset.css') }}" id="preset-style-link">
+<link rel="stylesheet" href="{{ asset('assets/css/trix.css') }}">

--- a/resources/views/dashboard/layouts/partials/js.blade.php
+++ b/resources/views/dashboard/layouts/partials/js.blade.php
@@ -1,0 +1,7 @@
+<script src="{{ asset('assets/js/plugins/popper.min.js') }}"></script>
+<script src="{{ asset('assets/js/plugins/simplebar.min.js') }}"></script>
+<script src="{{ asset('assets/js/plugins/bootstrap.min.js') }}"></script>
+<script src="{{ asset('assets/js/fonts/custom-font.js') }}"></script>
+<script src="{{ asset('assets/js/pcoded.js') }}"></script>
+<script src="{{ asset('assets/js/plugins/feather.min.js') }}"></script>
+<script src="{{ asset('assets/js/trix.js') }}"></script>


### PR DESCRIPTION
## Summary
- add slim CSS/JS partials for dashboard
- include these partials in dashboard layout
- drop heavy vendor assets from dashboard

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d283c60b8832cae78940cd20fbc74