### PR TITLE
Enhance alumni profiles with occupation and education data

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -42,9 +42,13 @@ class AccountController extends Controller
             'username' => ['required', 'max:255', Rule::unique('users')->ignore($user->id)],
             'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
             'bio' => 'nullable|string',
+            'occupation' => 'nullable|string|max:255',
+            'education_level' => 'nullable|string|max:255',
             'photo' => 'nullable|image|file|max:2048',
             'password' => ['nullable', 'min:5'],
         ]);
+
+        $validatedData['is_active'] = $request->has('is_active');
 
         if (empty($validatedData['password'])) {
             unset($validatedData['password']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,9 @@ class User extends Authenticatable
         'bio',
         'photo',
         'is_admin',
+        'occupation',
+        'education_level',
+        'is_active',
     ];
 
     // protected $guarded = ['id'];
@@ -48,6 +51,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'is_admin' => 'boolean',
+            'is_active' => 'boolean',
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -32,6 +32,9 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
             'is_admin' => false,
             'bio' => fake()->paragraph(),
+            'occupation' => fake()->jobTitle(),
+            'education_level' => fake()->randomElement(['High School', 'Diploma', 'Bachelor', 'Master', 'Doctorate']),
+            'is_active' => fake()->boolean(80),
         ];
     }
 

--- a/database/migrations/2025_07_01_000003_add_profile_fields_to_users_table.php
+++ b/database/migrations/2025_07_01_000003_add_profile_fields_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('occupation')->nullable()->after('photo');
+            $table->string('education_level')->nullable()->after('occupation');
+            $table->boolean('is_active')->default(true)->after('education_level');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['occupation', 'education_level', 'is_active']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,6 +34,9 @@ class DatabaseSeeder extends Seeder
             'email' => 'zennovan@gmail.com',
             'password' => bcrypt('admin123'),
             'is_admin' => true,
+            'occupation' => 'Administrator',
+            'education_level' => 'Bachelor',
+            'is_active' => true,
         ]);
 
 

--- a/resources/views/alumni/index.blade.php
+++ b/resources/views/alumni/index.blade.php
@@ -17,6 +17,13 @@
                                     {{ $user->name }}
                                 </a>
                             </h5>
+                            @if($user->occupation)
+                                <p class="mb-1"><strong>Occupation:</strong> {{ $user->occupation }}</p>
+                            @endif
+                            @if($user->education_level)
+                                <p class="mb-1"><strong>Education:</strong> {{ $user->education_level }}</p>
+                            @endif
+                            <p class="mb-1"><strong>Status:</strong> {{ $user->is_active ? 'Active' : 'Inactive' }}</p>
                             @if($user->bio)
                                 <p class="card-text">{{ Str::limit($user->bio, 80) }}</p>
                             @endif

--- a/resources/views/alumni/show.blade.php
+++ b/resources/views/alumni/show.blade.php
@@ -6,6 +6,13 @@
         @if($alumnus->photo)
             <img src="{{ asset('storage/' . $alumnus->photo) }}" alt="Profile Photo" class="img-thumbnail mb-3" width="150">
         @endif
+        @if($alumnus->occupation)
+            <p><strong>Occupation:</strong> {{ $alumnus->occupation }}</p>
+        @endif
+        @if($alumnus->education_level)
+            <p><strong>Education:</strong> {{ $alumnus->education_level }}</p>
+        @endif
+        <p><strong>Status:</strong> {{ $alumnus->is_active ? 'Active' : 'Inactive' }}</p>
         @if($alumnus->bio)
             <p class="mb-4">{{ $alumnus->bio }}</p>
         @endif

--- a/resources/views/dashboard/account/edit.blade.php
+++ b/resources/views/dashboard/account/edit.blade.php
@@ -35,6 +35,24 @@
             @enderror
         </div>
         <div class="mb-3">
+            <label for="occupation" class="form-label">Occupation</label>
+            <input type="text" class="form-control @error('occupation') is-invalid @enderror" id="occupation" name="occupation" value="{{ old('occupation', $user->occupation) }}">
+            @error('occupation')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3">
+            <label for="education_level" class="form-label">Education Level</label>
+            <input type="text" class="form-control @error('education_level') is-invalid @enderror" id="education_level" name="education_level" value="{{ old('education_level', $user->education_level) }}">
+            @error('education_level')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="mb-3 form-check">
+            <input type="checkbox" class="form-check-input" id="is_active" name="is_active" value="1" {{ old('is_active', $user->is_active) ? 'checked' : '' }}>
+            <label class="form-check-label" for="is_active">Active Alumni</label>
+        </div>
+        <div class="mb-3">
             <label for="photo" class="form-label">Photo</label>
             @if($user->photo)
                 <img src="{{ asset('storage/' . $user->photo) }}" alt="Current Photo" class="img-thumbnail d-block mb-2" width="150">

--- a/resources/views/dashboard/account/show.blade.php
+++ b/resources/views/dashboard/account/show.blade.php
@@ -17,6 +17,16 @@
             <dt class="col-sm-3">Bio</dt>
             <dd class="col-sm-9">{{ $user->bio }}</dd>
         @endif
+        @if($user->occupation)
+            <dt class="col-sm-3">Occupation</dt>
+            <dd class="col-sm-9">{{ $user->occupation }}</dd>
+        @endif
+        @if($user->education_level)
+            <dt class="col-sm-3">Education Level</dt>
+            <dd class="col-sm-9">{{ $user->education_level }}</dd>
+        @endif
+        <dt class="col-sm-3">Status</dt>
+        <dd class="col-sm-9">{{ $user->is_active ? 'Active' : 'Inactive' }}</dd>
     </dl>
     <a href="{{ route('account.edit') }}" class="btn btn-primary">Edit Profile</a>
 </div>


### PR DESCRIPTION
## Summary
- store alumni occupation, education level, and active status in new migration
- expose new fields via User model
- show and edit the fields in dashboard profile pages
- display alumni progress on alumni index and detail pages
- seed faker data and admin defaults for new fields

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3e7d2b8c832cb35bb0d71e95c21a